### PR TITLE
Apparently sectionid is now a string

### DIFF
--- a/websocket_client.go
+++ b/websocket_client.go
@@ -16,7 +16,7 @@ type TimelineEntry struct {
 	Identifier    string `json:"identifier"`
 	ItemID        int64  `json:"itemID"`
 	MetadataState string `json:"metadataState"`
-	SectionID     string  `json:"sectionID"`
+	SectionID     int64  `json:"sectionID,string"`
 	State         int64  `json:"state"`
 	Title         string `json:"title"`
 	Type          int64  `json:"type"`

--- a/websocket_client.go
+++ b/websocket_client.go
@@ -16,7 +16,7 @@ type TimelineEntry struct {
 	Identifier    string `json:"identifier"`
 	ItemID        int64  `json:"itemID"`
 	MetadataState string `json:"metadataState"`
-	SectionID     int64  `json:"sectionID"`
+	SectionID     string  `json:"sectionID"`
 	State         int64  `json:"state"`
 	Title         string `json:"title"`
 	Type          int64  `json:"type"`


### PR DESCRIPTION
plex-exporter-0 main convert message to json failed: json: cannot unmarshal string into Go struct field TimelineEntry.NotificationContainer.TimelineEntry.sectionID of type int64